### PR TITLE
Add option to disable same section MIPS branch relocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [v0.10] - 2026-06-03
+
+### Added
+
+- Add `-mbranch-relocs` and `-mno-branch-relocs` options.
+  - Allows same section MIPS PC16 branch targets to be resolved without emitting `R_MIPS_PC16` relocations when possible.
+
 ## [v0.9] - 2026-06-01
 
 ### Added
@@ -84,6 +91,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Add support for `R_MIPS15_S3` reloc.
 - Setup Github Action releases.
 
+[v0.10]: https://github.com/decompals/binutils-mips-ps2-decompals/compare/v0.9...v0.10
 [v0.9]: https://github.com/decompals/binutils-mips-ps2-decompals/compare/v0.8...v0.9
 [v0.8]: https://github.com/decompals/binutils-mips-ps2-decompals/compare/v0.7...v0.8
 [v0.7]: https://github.com/decompals/binutils-mips-ps2-decompals/compare/v0.6...v0.7

--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ to check the latest release.
   - Allows to override the alignment of any given section.
   - Up to 16 sections can be specified by passing the flag multiple times.
   - If a section is specified more than once then the last alignment is used.
+- Flag to control MIPS branch relocations.
+  - Syntax is `-mbranch-relocs` and `-mno-branch-relocs`.
+  - Allows same section MIPS PC16 branch targets to be resolved without emitting `R_MIPS_PC16` relocations when possible.

--- a/gas/config/tc-mips.c
+++ b/gas/config/tc-mips.c
@@ -15546,8 +15546,7 @@ mips_force_relocation (fixS *fixp)
       if (mips_branch_relocs
 	  || fixp->fx_r_type != BFD_RELOC_16_PCREL_S2
 	  || fixp->fx_addsy == NULL
-	  || S_FORCE_RELOC (fixp->fx_addsy, 0)
-	  || S_IS_WEAK (fixp->fx_addsy))
+	  || S_FORCE_RELOC (fixp->fx_addsy, 0))
 	return 1;
     }
 

--- a/gas/config/tc-mips.c
+++ b/gas/config/tc-mips.c
@@ -980,6 +980,10 @@ static int mips_relax_branch;
    Needed for broken assembly produced by some GCC versions and some
    sloppy code out there, where branches to data labels are present.  */
 static bool mips_ignore_branch_isa;
+
+/* True if branch relocations should be kept for global symbols.
+   This preserves the default ELF behavior.  */
+static bool mips_branch_relocs = true;
 
 /* The expansion of many macros depends on the type of symbol that
    they refer to.  For example, when generating position-dependent code,
@@ -1538,6 +1542,8 @@ enum options
     OPTION_NO_RELAX_BRANCH,
     OPTION_IGNORE_BRANCH_ISA,
     OPTION_NO_IGNORE_BRANCH_ISA,
+    OPTION_BRANCH_RELOCS,
+    OPTION_NO_BRANCH_RELOCS,
     OPTION_INSN32,
     OPTION_NO_INSN32,
     OPTION_MSHARED,
@@ -1694,6 +1700,8 @@ struct option md_longopts[] =
   {"no-relax-branch", no_argument, NULL, OPTION_NO_RELAX_BRANCH},
   {"mignore-branch-isa", no_argument, NULL, OPTION_IGNORE_BRANCH_ISA},
   {"mno-ignore-branch-isa", no_argument, NULL, OPTION_NO_IGNORE_BRANCH_ISA},
+  {"mbranch-relocs", no_argument, NULL, OPTION_BRANCH_RELOCS},
+  {"mno-branch-relocs", no_argument, NULL, OPTION_NO_BRANCH_RELOCS},
   {"minsn32", no_argument, NULL, OPTION_INSN32},
   {"mno-insn32", no_argument, NULL, OPTION_NO_INSN32},
   {"mshared", no_argument, NULL, OPTION_MSHARED},
@@ -15054,6 +15062,14 @@ md_parse_option (int c, const char *arg)
       mips_ignore_branch_isa = false;
       break;
 
+    case OPTION_BRANCH_RELOCS:
+      mips_branch_relocs = true;
+      break;
+
+    case OPTION_NO_BRANCH_RELOCS:
+      mips_branch_relocs = false;
+      break;
+
     case OPTION_INSN32:
       file_mips_opts.insn32 = true;
       break;
@@ -15526,7 +15542,14 @@ int
 mips_force_relocation (fixS *fixp)
 {
   if (generic_force_reloc (fixp))
-    return 1;
+    {
+      if (mips_branch_relocs
+	  || fixp->fx_r_type != BFD_RELOC_16_PCREL_S2
+	  || fixp->fx_addsy == NULL
+	  || S_FORCE_RELOC (fixp->fx_addsy, 0)
+	  || S_IS_WEAK (fixp->fx_addsy))
+	return 1;
+    }
 
   /* We want to keep BFD_RELOC_MICROMIPS_*_PCREL_S1 relocation,
      so that the linker relaxation can update targets.  */
@@ -20472,6 +20495,8 @@ MIPS options:\n\
 --[no-]relax-branch	[dis]allow out-of-range branches to be relaxed\n\
 -mignore-branch-isa	accept invalid branches requiring an ISA mode switch\n\
 -mno-ignore-branch-isa	reject invalid branches requiring an ISA mode switch\n\
+-mbranch-relocs		emit relocations for branches to external symbols\n\
+-mno-branch-relocs	resolve same-section branch targets without relocations\n\
 -mnan=ENCODING		select an IEEE 754 NaN encoding convention, either of:\n"));
 
   first = 1;

--- a/gas/doc/as.texi
+++ b/gas/doc/as.texi
@@ -456,6 +456,7 @@ gcc(1), ld(1), and the Info entries for @file{binutils} and @file{ld}.
    [@b{-mips64r3}] [@b{-mips64r5}] [@b{-mips64r6}]
    [@b{-construct-floats}] [@b{-no-construct-floats}]
    [@b{-mignore-branch-isa}] [@b{-mno-ignore-branch-isa}]
+   [@b{-mbranch-relocs}] [@b{-mno-branch-relocs}]
    [@b{-mnan=@var{encoding}}]
    [@b{-trap}] [@b{-no-break}] [@b{-break}] [@b{-no-trap}]
    [@b{-mips16}] [@b{-no-mips16}]
@@ -1743,6 +1744,12 @@ checks implemented that verify in branch assembly that the two ISA
 modes match.  @samp{-mignore-branch-isa} disables these checks.  By
 default @samp{-mno-ignore-branch-isa} is selected, causing any invalid
 branch requiring a transition between ISA modes to produce an error.
+
+@item -mbranch-relocs
+@itemx -mno-branch-relocs
+Emit relocations for branches to external symbols, or resolve branch
+targets in the same section without relocations when possible.  By
+default @samp{-mbranch-relocs} is selected.
 
 @item -mnan=@var{encoding}
 Select between the IEEE 754-2008 (@option{-mnan=2008}) or the legacy

--- a/gas/doc/c-mips.texi
+++ b/gas/doc/c-mips.texi
@@ -568,6 +568,14 @@ for branches.
 By default @samp{-mno-ignore-branch-isa} is selected, causing any invalid
 branch requiring a transition between ISA modes to produce an error.
 
+@item -mbranch-relocs
+@itemx -mno-branch-relocs
+Emit relocations for branches to external symbols, or resolve branch
+targets in the same section without relocations when possible.
+
+By default @samp{-mbranch-relocs} is selected, preserving normal ELF
+semantics for branches to external symbols.
+
 @cindex @option{-mnan=} command-line option, MIPS
 @item -mnan=@var{encoding}
 This option indicates whether the source code uses the IEEE 2008

--- a/gas/testsuite/gas/mips/branch-misc-2-no-branch-relocs.d
+++ b/gas/testsuite/gas/mips/branch-misc-2-no-branch-relocs.d
@@ -1,0 +1,29 @@
+#objdump: -dr --prefix-addresses --show-raw-insn
+#name: MIPS branch-misc-2-no-branch-relocs
+#source: branch-misc-2.s
+#as: -32 -non_shared -mno-branch-relocs
+
+# Test resolving branches to global symbols in current file.
+
+.*: +file format .*mips.*
+
+Disassembly of section .text:
+	\.\.\.
+	\.\.\.
+	\.\.\.
+0+003c <[^>]*> 0411fff0 	bal	00000000 <g1>
+0+0040 <[^>]*> 00000000 	nop
+0+0044 <[^>]*> 0411fff3 	bal	00000014 <g2>
+0+0048 <[^>]*> 00000000 	nop
+0+004c <[^>]*> 0411fff6 	bal	00000028 <g3>
+0+0050 <[^>]*> 00000000 	nop
+0+0054 <[^>]*> 0411000a 	bal	00000080 <g4>
+0+0058 <[^>]*> 00000000 	nop
+0+005c <[^>]*> 0411000d 	bal	00000094 <g5>
+0+0060 <[^>]*> 00000000 	nop
+0+0064 <[^>]*> 04110010 	bal	000000a8 <g6>
+0+0068 <[^>]*> 00000000 	nop
+	\.\.\.
+	\.\.\.
+	\.\.\.
+	\.\.\.

--- a/gas/testsuite/gas/mips/branch-weak-8.d
+++ b/gas/testsuite/gas/mips/branch-weak-8.d
@@ -1,0 +1,14 @@
+#objdump: -dr --prefix-addresses --show-raw-insn
+#name: MIPS weak branch without branch relocs
+#as: -32 -mno-branch-relocs --defsym align=12
+#source: branch-weak.s
+
+.*: +file format .*mips.*
+
+Disassembly of section \.text:
+[0-9a-f]+ <[^>]*> 100003ff 	b	00001000 <bar>
+[0-9a-f]+ <[^>]*> 00000000 	nop
+	\.\.\.
+[0-9a-f]+ <[^>]*> 03e00008 	jr	ra
+[0-9a-f]+ <[^>]*> 00000000 	nop
+	\.\.\.

--- a/gas/testsuite/gas/mips/mips.exp
+++ b/gas/testsuite/gas/mips/mips.exp
@@ -644,6 +644,7 @@ if { [istarget mips*-*-vxworks*] } {
     run_dump_test "branch-weak-5"
     run_dump_test "branch-weak-6"
     run_dump_test "branch-weak-7"
+    run_dump_test "branch-weak-8"
     run_dump_test "branch-local-1"
     run_dump_test "branch-local-2"
     run_dump_test "branch-local-ignore-2"

--- a/gas/testsuite/gas/mips/mips.exp
+++ b/gas/testsuite/gas/mips/mips.exp
@@ -595,6 +595,7 @@ if { [istarget mips*-*-vxworks*] } {
     run_dump_test_arches "branch-likely" [mips_arch_list_matching mips2 !mips32r6]
     run_dump_test_arches "branch-misc-1" [mips_arch_list_matching mips1]
     run_dump_test_arches "branch-misc-2" [mips_arch_list_matching mips1]
+    run_dump_test_arches "branch-misc-2-no-branch-relocs" [mips_arch_list_matching mips1]
     run_dump_test_arches "branch-misc-2pic" [mips_arch_list_matching mips1]
     run_dump_test "branch-misc-3"
     run_dump_test_arches "branch-misc-4" [mips_arch_list_matching mips1]


### PR DESCRIPTION
## Summary

- Add a `-mbranch-relocs` / `-mno-branch-relocs` option to control MIPS PC16 branch relocations.
- Keep the default enabled to preserve existing ELF behavior.
- Allow same section global branch targets to be resolved at assembly time when branch relocs are disabled.

Thanks to @dreamingmoths and @Mc-muffin for the help.

## Context

GNU AS currently keeps `R_MIPS_PC16` relocations for branches to global symbols, even when the target is defined in the same section and could be resolved by the assembler.

For example, generated assembly contains branches like:

```asm
/* 1D8 00100158 07004410 */  beq        $v0, $a0, func_00100178
...
alabel func_00100178
```

and:

```asm
/* CD20 0010CCA0 CC016010 */  beqz       $v1, .L0010D3D4
```

With the existing behavior, GNU AS emits an object with an embedded branch addend plus an `R_MIPS_PC16` relocation for global branch targets. GNU linkers handle this convention, but some non-GNU linkers, such as MWLD, expect no embedded branch fixup for this case and resolve the final branch offset incorrectly.

One observed result was a one slot branch offset mismatch after linking:

```text
0x00100158: expected 07004410, rebuilt 06004410
```

Another observed mismatch was:

```text
0x0010CCA0: expected 106001CC, rebuilt 106001CB
```

This is a problem for generated assembly where branch targets may be emitted as global labels for symbol ownership reasons, but the target is still safely in the same section.

This PR adds an option:

```sh
-mbranch-relocs
-mno-branch-relocs
```

When enabled, behavior stays unchanged. When disabled, GNU AS allows same section `BFD_RELOC_16_PCREL_S2` branch targets to be resolved without emitting `R_MIPS_PC16` relocations where possible.

The option is intentionally scoped to regular MIPS PC16 branch relocations. Existing safeguards for microMIPS relocations, compressed mode branch diagnostics, weak/undefined symbols, and R6 relaxation remain in place.

## Notes

- This is intended for generated assembly that needs normal branch mnemonics while linking with non-GNU linkers.
- The default remains `-mbranch-relocs`, so existing ELF output is preserved unless the new option is explicitly selected.

## Testing

- Added a GNU AS testsuite case for branches to global symbols in the same file with `-mno-branch-relocs`.
- Verified the existing `branch-misc-2` behavior remains unchanged by default.
- Verified the [Sonic Riders Zero Gravity](https://github.com/KidWizardOfTheWeb/SR2) decompilation project builds successfully using the updated assembler